### PR TITLE
Validate Terraform backend config

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -91,9 +91,9 @@ func (c ClusterType) String() string {
 }
 
 type TerraformBackendConfig struct {
-	Hostname     string `hcl:"hostname"`
-	Organization string `hcl:"organization"`
+	Hostname     string `hcl:"hostname" validate:"required"`
+	Organization string `hcl:"organization" validate:"required"`
 	Workspaces   struct {
-		Prefix string `hcl:"prefix"`
+		Prefix string `hcl:"prefix" validate:"required"`
 	} `hcl:"workspaces,block"`
 }

--- a/api/validation.go
+++ b/api/validation.go
@@ -48,3 +48,21 @@ func ValidateCluster(cluster Cluster) error {
 	}
 	return nil
 }
+
+func ValidateBackendConfig(backendConfig TerraformBackendConfig) error {
+	if err := validate.Struct(backendConfig); err != nil {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			var errorChain error
+			for _, err := range validationErrors {
+				errorChain = multierror.Append(
+					errorChain,
+					fmt.Errorf(err.Translate(translator)),
+				)
+			}
+			return errorChain
+		}
+		return err
+	}
+	return nil
+}

--- a/client/cluster.go
+++ b/client/cluster.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -674,28 +673,6 @@ func (c *ClusterClient) encryptKubeconfig() error {
 	return nil
 }
 
-func (c *ClusterClient) readTerraformBackendConfig() (api.TerraformBackendConfig, error) {
-	var backendConfig api.TerraformBackendConfig
-
-	f, err := os.Open(c.configHandler.configPath[api.TFBackendConfigFile].Path)
-	if err != nil {
-		return backendConfig, fmt.Errorf("error opening file: %w", err)
-	}
-
-	backendConfigBytes, err := ioutil.ReadAll(f)
-	if err != nil {
-		return backendConfig, fmt.Errorf("error reading file: %w", err)
-	}
-
-	if len(backendConfigBytes) > 0 {
-		if err := hclDecode(backendConfigBytes, &backendConfig); err != nil {
-			return backendConfig, fmt.Errorf("error can't decode terraform backend: %w", err)
-		}
-	}
-
-	return backendConfig, nil
-}
-
 func (c *ClusterClient) terraformRemoteWorkspaceApply() error {
 	c.logger.Debug("client_terraform_remote_workspace_apply")
 
@@ -708,7 +685,7 @@ func (c *ClusterClient) terraformRemoteWorkspaceApply() error {
 		return fmt.Errorf("error initializing TFE workspace: %w", err)
 	}
 
-	backendConfig, err := c.readTerraformBackendConfig()
+	backendConfig, err := c.configHandler.readTerraformBackendConfig()
 	if err != nil {
 		return fmt.Errorf("error reading terraform backend config: %w", err)
 	}
@@ -732,7 +709,7 @@ func (c *ClusterClient) terraformRemoteWorkspaceDestroy() error {
 		return fmt.Errorf("error initializing TFE workspace: %w", err)
 	}
 
-	backendConfig, err := c.readTerraformBackendConfig()
+	backendConfig, err := c.configHandler.readTerraformBackendConfig()
 	if err != nil {
 		return fmt.Errorf("error reading terraform backend config: %w", err)
 	}

--- a/client/config.go
+++ b/client/config.go
@@ -409,3 +409,31 @@ func (c *ConfigHandler) WriteInfraJSON(
 
 	return nil
 }
+
+func (c *ConfigHandler) readTerraformBackendConfig() (
+	api.TerraformBackendConfig,
+	error,
+) {
+	var backendConfig api.TerraformBackendConfig
+
+	f, err := os.Open(c.configPath[api.TFBackendConfigFile].Path)
+	if err != nil {
+		return backendConfig, fmt.Errorf("error opening file: %w", err)
+	}
+
+	backendConfigBytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		return backendConfig, fmt.Errorf("error reading file: %w", err)
+	}
+
+	if len(backendConfigBytes) > 0 {
+		if err := hclDecode(backendConfigBytes, &backendConfig); err != nil {
+			return backendConfig, fmt.Errorf(
+				"error can't decode terraform backend: %w",
+				err,
+			)
+		}
+	}
+
+	return backendConfig, nil
+}

--- a/client/config.go
+++ b/client/config.go
@@ -435,5 +435,9 @@ func (c *ConfigHandler) readTerraformBackendConfig() (
 		}
 	}
 
+	if err := api.ValidateBackendConfig(backendConfig); err != nil {
+		return backendConfig, err
+	}
+
 	return backendConfig, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Since organization is not being set by default anymore it's easy to end up with a failed initial apply if you forget to set it in the config. This makes it fail early and with a clear error message:

```
% go run ./cmd/ck8s --cluster sc apply                     
2020-09-23T15:56:29.610+0200	INFO	client/cluster.go:148	client_apply
Error: error reading terraform backend config: 1 error occurred:
	* Organization is a required field
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
