### PR TITLE
ansible: Fixed possibility to choose wrong IP when joining a node

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -49,6 +49,7 @@
 - Interactive runs with SSH commands (e.g. kubeadm reset) not working properly
   due to stdin being blocked after the SSH session closed.
 - Errors when cleaning up kubernetes on destroy is now handled properly
+- Making sure to select an active master IP when joining a new node
 
 ### Changed
 

--- a/ansible/templates/kubeadm-join-master.yaml.j2
+++ b/ansible/templates/kubeadm-join-master.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
-    apiServerEndpoint: "{{ control_plane_endpoint | default(hostvars[groups.masters.0].private_ip) }}:{{ control_plane_port | default(6443) }}"
+    apiServerEndpoint: "{{ control_plane_endpoint | default(hostvars[groups.masters_active.0].private_ip) }}:{{ control_plane_port | default(6443) }}"
     token: "{{ hostvars[groups.masters_active.0].join_token }}"
     caCertHashes:
     - "sha256:{{ hostvars[groups.masters_active.0].ca_key_hash }}"

--- a/ansible/templates/kubeadm-join.yaml.j2
+++ b/ansible/templates/kubeadm-join.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
-    apiServerEndpoint: "{{ control_plane_endpoint | default(hostvars[groups.masters.0].private_ip) }}:{{ control_plane_port | default(6443) }}"
+    apiServerEndpoint: "{{ control_plane_endpoint | default(hostvars[groups.masters_active.0].private_ip) }}:{{ control_plane_port | default(6443) }}"
     token: "{{ hostvars[groups.masters_active.0].join_token }}"
     caCertHashes:
     - "sha256:{{ hostvars[groups.masters_active.0].ca_key_hash }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix for when joining a new node and control_plane_endpoint is not set, it could choose a bad IP

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
