### PR TITLE
all: add disk size argument to exoscale machines

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,0 +1,2 @@
+### Added
+- Option to specify disk size on exoscale nodes.

--- a/api/exoscale/flavors.go
+++ b/api/exoscale/flavors.go
@@ -53,7 +53,9 @@ func Development(clusterType api.ClusterType, clusterName string) api.Cluster {
 		cloudProvider,
 		api.Master,
 		"Small",
-	).MustBuild()
+	).WithProviderSettings(map[string]interface{}{
+		"disk_size": 50,
+	}).MustBuild()
 
 	workerExtraLargeSC := api.NewMachineFactory(
 		cloudProvider,
@@ -63,6 +65,7 @@ func Development(clusterType api.ClusterType, clusterName string) api.Cluster {
 		// Match ES_DATA_STORAGE_SIZE in config.sh
 		// Note that this value is in GB while config.sh uses Gi
 		"es_local_storage_capacity": 12,
+		"disk_size":                 50,
 	}).MustBuild()
 
 	workerLargeSC := api.NewMachineFactory(
@@ -73,13 +76,16 @@ func Development(clusterType api.ClusterType, clusterName string) api.Cluster {
 		// Match ES_DATA_STORAGE_SIZE in config.sh
 		// Note that this value is in GB while config.sh uses Gi
 		"es_local_storage_capacity": 12,
+		"disk_size":                 50,
 	}).MustBuild()
 
 	workerWC := api.NewMachineFactory(
 		cloudProvider,
 		api.Worker,
 		"Large",
-	).MustBuild()
+	).WithProviderSettings(map[string]interface{}{
+		"disk_size": 50,
+	}).MustBuild()
 
 	cluster.tfvars.MachinesSC = map[string]*api.Machine{
 		"master-0": master,
@@ -92,6 +98,7 @@ func Development(clusterType api.ClusterType, clusterName string) api.Cluster {
 		"worker-0": workerWC,
 	}
 
+	cluster.tfvars.NFSDiskSize = 200
 	cluster.tfvars.NFSSize = "Small"
 
 	return cluster
@@ -110,13 +117,17 @@ func Production(clusterType api.ClusterType, clusterName string) api.Cluster {
 		cloudProvider,
 		api.Master,
 		"Medium",
-	).MustBuild()
+	).WithProviderSettings(map[string]interface{}{
+		"disk_size": 50,
+	}).MustBuild()
 
 	workerExtraLargeSC := api.NewMachineFactory(
 		cloudProvider,
 		api.Worker,
 		"Extra-large",
-	).MustBuild()
+	).WithProviderSettings(map[string]interface{}{
+		"disk_size": 50,
+	}).MustBuild()
 
 	workerLargeESSC := api.NewMachineFactory(
 		cloudProvider,
@@ -126,19 +137,24 @@ func Production(clusterType api.ClusterType, clusterName string) api.Cluster {
 		// Match ES_DATA_STORAGE_SIZE in config.sh
 		// Note that this value is in GB while config.sh uses Gi
 		"es_local_storage_capacity": 140,
+		"disk_size":                 200,
 	}).MustBuild()
 
 	workerLargeSC := api.NewMachineFactory(
 		cloudProvider,
 		api.Worker,
 		"Large",
-	).MustBuild()
+	).WithProviderSettings(map[string]interface{}{
+		"disk_size": 50,
+	}).MustBuild()
 
 	workerWC := api.NewMachineFactory(
 		cloudProvider,
 		api.Worker,
 		"Large",
-	).MustBuild()
+	).WithProviderSettings(map[string]interface{}{
+		"disk_size": 50,
+	}).MustBuild()
 
 	cluster.tfvars.MachinesSC = map[string]*api.Machine{
 		"master-0": master,
@@ -161,6 +177,7 @@ func Production(clusterType api.ClusterType, clusterName string) api.Cluster {
 	}
 
 	cluster.tfvars.NFSSize = "Small"
+	cluster.tfvars.NFSDiskSize = 200
 
 	return cluster
 }

--- a/api/exoscale/flavors_test.go
+++ b/api/exoscale/flavors_test.go
@@ -83,6 +83,9 @@ func TestFlavors(t *testing.T) {
 						NodeType: api.Master,
 						Size:     "Small",
 						Image:    latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-0": {
 						NodeType: api.Worker,
@@ -90,6 +93,7 @@ func TestFlavors(t *testing.T) {
 						Image:    latestImage,
 						ProviderSettings: &MachineSettings{
 							ESLocalStorageCapacity: 12,
+							DiskSize:               50,
 						},
 					},
 					"worker-1": {
@@ -98,6 +102,7 @@ func TestFlavors(t *testing.T) {
 						Image:    latestImage,
 						ProviderSettings: &MachineSettings{
 							ESLocalStorageCapacity: 12,
+							DiskSize:               50,
 						},
 					},
 				},
@@ -106,14 +111,21 @@ func TestFlavors(t *testing.T) {
 						NodeType: api.Master,
 						Size:     "Small",
 						Image:    latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-0": {
 						NodeType: api.Worker,
 						Size:     "Large",
 						Image:    latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 				},
-				NFSSize: "Small",
+				NFSSize:     "Small",
+				NFSDiskSize: 200,
 			},
 		},
 		got: Development(clusterType, clusterName),
@@ -152,24 +164,36 @@ func TestFlavors(t *testing.T) {
 						Size:     "Medium",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"master-1": {
 						NodeType: api.Master,
 						Size:     "Medium",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"master-2": {
 						NodeType: api.Master,
 						Size:     "Medium",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-0": {
 						NodeType: api.Worker,
 						Size:     "Extra-large",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-1": {
 						NodeType: api.Worker,
@@ -178,6 +202,7 @@ func TestFlavors(t *testing.T) {
 						Image: latestImage,
 						ProviderSettings: &MachineSettings{
 							ESLocalStorageCapacity: 140,
+							DiskSize:               200,
 						},
 					},
 					"worker-2": {
@@ -187,6 +212,7 @@ func TestFlavors(t *testing.T) {
 						Image: latestImage,
 						ProviderSettings: &MachineSettings{
 							ESLocalStorageCapacity: 140,
+							DiskSize:               200,
 						},
 					},
 					"worker-3": {
@@ -194,6 +220,9 @@ func TestFlavors(t *testing.T) {
 						Size:     "Large",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 				},
 				MachinesWC: map[string]*api.Machine{
@@ -202,45 +231,67 @@ func TestFlavors(t *testing.T) {
 						Size:     "Medium",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"master-1": {
 						NodeType: api.Master,
 						Size:     "Medium",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"master-2": {
 						NodeType: api.Master,
 						Size:     "Medium",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-ck8s-0": {
 						NodeType: api.Worker,
 						Size:     "Large",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-0": {
 						NodeType: api.Worker,
 						Size:     "Large",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-1": {
 						NodeType: api.Worker,
 						Size:     "Large",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 					"worker-2": {
 						NodeType: api.Worker,
 						Size:     "Large",
 
 						Image: latestImage,
+						ProviderSettings: &MachineSettings{
+							DiskSize: 50,
+						},
 					},
 				},
-				NFSSize: "Small",
+				NFSSize:     "Small",
+				NFSDiskSize: 200,
 			},
 		},
 		got: Production(clusterType, clusterName),

--- a/api/exoscale/tfvars.go
+++ b/api/exoscale/tfvars.go
@@ -8,6 +8,7 @@ import (
 
 type MachineSettings struct {
 	ESLocalStorageCapacity int `json:"es_local_storage_capacity"`
+	DiskSize               int `json:"disk_size"`
 }
 
 type ExoscaleTFVars struct {
@@ -17,7 +18,8 @@ type ExoscaleTFVars struct {
 	MachinesSC map[string]*api.Machine `json:"machines_sc" validate:"required,min=1"`
 	MachinesWC map[string]*api.Machine `json:"machines_wc" validate:"required,min=1"`
 
-	NFSSize string `json:"nfs_size" validate:"required"`
+	NFSSize     string `json:"nfs_size" validate:"required"`
+	NFSDiskSize int    `json:"nfs_disk_size" validate:"required"`
 
 	PublicIngressCIDRWhitelist []string `json:"public_ingress_cidr_whitelist" validate:"required"`
 

--- a/api/exoscale/tfvars_test.go
+++ b/api/exoscale/tfvars_test.go
@@ -18,6 +18,7 @@ func TestAddMachine(t *testing.T) {
 		Image:    api.NewImage("test", "v1.2.3"),
 		ProviderSettings: MachineSettings{
 			ESLocalStorageCapacity: 10,
+			DiskSize:               50,
 		},
 	}
 
@@ -65,6 +66,7 @@ func TestAddMachineWithName(t *testing.T) {
 		Image:    api.NewImage("test", "v1.2.3"),
 		ProviderSettings: MachineSettings{
 			ESLocalStorageCapacity: 10,
+			DiskSize:               50,
 		},
 	}
 
@@ -114,6 +116,7 @@ func TestRemoveMachine(t *testing.T) {
 				Image:    api.NewImage("test", "v1.2.3"),
 				ProviderSettings: MachineSettings{
 					ESLocalStorageCapacity: 10,
+					DiskSize:               50,
 				},
 			},
 		},
@@ -122,6 +125,9 @@ func TestRemoveMachine(t *testing.T) {
 				NodeType: api.Worker,
 				Size:     "Large",
 				Image:    api.NewImage("test", "v1.2.3"),
+				ProviderSettings: MachineSettings{
+					DiskSize: 50,
+				},
 			},
 		},
 	}

--- a/client/cluster_test.go
+++ b/client/cluster_test.go
@@ -117,8 +117,10 @@ func TestAddMachine(t *testing.T) {
 	firstImageMaster := cloudProvider.MachineImages(api.Master)[0]
 
 	esLocalStorageCapacity := 10
+	diskSize := 50
 	providerSettings := &exoscale.MachineSettings{
 		ESLocalStorageCapacity: esLocalStorageCapacity,
+		DiskSize:               diskSize,
 	}
 
 	for _, testCase := range []struct {
@@ -160,12 +162,28 @@ func TestAddMachine(t *testing.T) {
 			Image:            firstImageMaster,
 			ProviderSettings: providerSettings,
 		},
+		"",
+		api.Master,
+		size,
+		firstImageMaster,
+		map[string]interface{}{
+			"es_local_storage_capacity": esLocalStorageCapacity,
+			"disk_size":                 diskSize,
+		},
+	}, {
+		&api.Machine{
+			NodeType:         api.Master,
+			Size:             size,
+			Image:            firstImageMaster,
+			ProviderSettings: providerSettings,
+		},
 		"master-1",
 		api.Master,
 		size,
 		firstImageMaster,
 		map[string]interface{}{
 			"es_local_storage_capacity": esLocalStorageCapacity,
+			"disk_size":                 diskSize,
 		},
 	}} {
 		logTest, logger := testutil.NewTestLogger([]string{
@@ -295,6 +313,7 @@ func TestCloneMachine(t *testing.T) {
 		Image:    api.NewImage("image", "v1.2.3"),
 		ProviderSettings: &exoscale.MachineSettings{
 			ESLocalStorageCapacity: 10,
+			DiskSize:               50,
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -331,6 +350,7 @@ func TestCloneMachine(t *testing.T) {
 			Image:    api.NewImage("image", "v1.2.3"),
 			ProviderSettings: &exoscale.MachineSettings{
 				ESLocalStorageCapacity: 10,
+				DiskSize:               50,
 			},
 		},
 		cloneMachineName: {
@@ -339,6 +359,7 @@ func TestCloneMachine(t *testing.T) {
 			Image:    api.NewImage("image", "v1.2.3"),
 			ProviderSettings: &exoscale.MachineSettings{
 				ESLocalStorageCapacity: 10,
+				DiskSize:               50,
 			},
 		},
 	}
@@ -383,6 +404,7 @@ func TestCloneMachineWithImage(t *testing.T) {
 			Image:    api.NewImage("image", image.KubeletVersion.String()),
 			ProviderSettings: &exoscale.MachineSettings{
 				ESLocalStorageCapacity: 10,
+				DiskSize:               50,
 			},
 		},
 	); err != nil {
@@ -423,6 +445,7 @@ func TestCloneMachineWithImage(t *testing.T) {
 			Image:    api.NewImage("image", "v1.2.3"),
 			ProviderSettings: &exoscale.MachineSettings{
 				ESLocalStorageCapacity: 10,
+				DiskSize:               50,
 			},
 		},
 		cloneMachineName: {
@@ -431,6 +454,7 @@ func TestCloneMachineWithImage(t *testing.T) {
 			Image:    image,
 			ProviderSettings: &exoscale.MachineSettings{
 				ESLocalStorageCapacity: 10,
+				DiskSize:               50,
 			},
 		},
 	}
@@ -508,6 +532,7 @@ func TestCloneMachineUnsupportedImageError(t *testing.T) {
 		Image:    api.NewImage("image", "v1.2.3"),
 		ProviderSettings: &exoscale.MachineSettings{
 			ESLocalStorageCapacity: 10,
+			DiskSize:               50,
 		},
 	}); err != nil {
 		t.Fatal(err)

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -33,6 +33,9 @@ func TestTFVarsRead(t *testing.T) {
 					Image: &api.Image{
 						Name: "testimage",
 					},
+					ProviderSettings: &exoscale.MachineSettings{
+						DiskSize: 50,
+					},
 				},
 				"worker-0": {
 					NodeType: api.Worker,
@@ -42,6 +45,7 @@ func TestTFVarsRead(t *testing.T) {
 					},
 					ProviderSettings: &exoscale.MachineSettings{
 						ESLocalStorageCapacity: 26,
+						DiskSize:               50,
 					},
 				},
 				"worker-1": {
@@ -52,6 +56,7 @@ func TestTFVarsRead(t *testing.T) {
 					},
 					ProviderSettings: &exoscale.MachineSettings{
 						ESLocalStorageCapacity: 26,
+						DiskSize:               50,
 					},
 				},
 			},
@@ -62,6 +67,7 @@ func TestTFVarsRead(t *testing.T) {
 					Image: &api.Image{
 						Name: "testimage",
 					},
+					ProviderSettings: nil,
 				},
 				"worker-0": {
 					NodeType: api.Worker,
@@ -69,9 +75,11 @@ func TestTFVarsRead(t *testing.T) {
 					Image: &api.Image{
 						Name: "testimage",
 					},
+					ProviderSettings: nil,
 				},
 			},
 			NFSSize:                    "Small",
+			NFSDiskSize:                200,
 			PublicIngressCIDRWhitelist: []string{"1.2.3.4/32", "4.3.2.1/32"},
 			APIServerWhitelist:         []string{"1.2.3.4/32", "4.3.2.1/32"},
 			NodeportWhitelist:          []string{"1.2.3.4/32", "4.3.2.1/32"},

--- a/client/testdata/exoscale-tfvars.json
+++ b/client/testdata/exoscale-tfvars.json
@@ -7,7 +7,9 @@
       "image": {
         "name": "testimage"
       },
-      "provider_settings": null
+      "provider_settings": {
+        "disk_size": 50
+      }
     },
     "worker-0": {
       "node_type": "worker",
@@ -16,7 +18,8 @@
         "name": "testimage"
       },
       "provider_settings": {
-        "es_local_storage_capacity": 26
+        "es_local_storage_capacity": 26,
+        "disk_size": 50
       }
     },
     "worker-1": {
@@ -26,7 +29,8 @@
         "name": "testimage"
       },
       "provider_settings": {
-        "es_local_storage_capacity": 26
+        "es_local_storage_capacity": 26,
+        "disk_size": 50
       }
     }
   },
@@ -49,6 +53,7 @@
     }
   },
   "nfs_size": "Small",
+  "nfs_disk_size": 200,
   "nodeport_whitelist": ["1.2.3.4/32", "4.3.2.1/32"],
   "prefix_sc": "",
   "prefix_wc": "",

--- a/terraform/exoscale/main.tf
+++ b/terraform/exoscale/main.tf
@@ -18,6 +18,7 @@ module "service_cluster" {
   machines = var.machines_sc
 
   nfs_size = var.nfs_size
+  nfs_disk_size = var.nfs_disk_size
 
   dns_suffix = "a1ck.io"
   dns_prefix = var.dns_prefix
@@ -46,6 +47,7 @@ module "workload_cluster" {
   machines = var.machines_wc
 
   nfs_size = var.nfs_size
+  nfs_disk_size = var.nfs_disk_size
 
   dns_suffix = "a1ck.io"
   dns_prefix = var.dns_prefix

--- a/terraform/exoscale/modules/kubernetes-cluster/main.tf
+++ b/terraform/exoscale/modules/kubernetes-cluster/main.tf
@@ -62,7 +62,7 @@ resource "exoscale_compute" "master" {
   display_name    = "${var.prefix}-${each.key}"
   template_id     = data.exoscale_compute_template.os_image[each.key].id
   size            = each.value.size
-  disk_size       = 50
+  disk_size       = each.value.provider_settings == null ? 50 : each.value.provider_settings.disk_size > 10 ? each.value.provider_settings.disk_size : 50
   key_pair        = exoscale_ssh_keypair.ssh_key.name
   state           = "Running"
   zone            = var.zone
@@ -81,7 +81,7 @@ resource "exoscale_compute" "worker" {
   display_name    = "${var.prefix}-${each.key}"
   template_id     = data.exoscale_compute_template.os_image[each.key].id
   size            = each.value.size
-  disk_size       = 50
+  disk_size       = each.value.provider_settings == null ? 50 : each.value.provider_settings.disk_size > 10 ? each.value.provider_settings.disk_size : 50
   key_pair        = exoscale_ssh_keypair.ssh_key.name
   state           = "Running"
   zone            = var.zone
@@ -100,7 +100,7 @@ resource "exoscale_compute" "nfs" {
   display_name    = "${var.prefix}-nfs"
   template_id     = data.exoscale_compute_template.ubuntu.id
   size            = var.nfs_size
-  disk_size       = 200
+  disk_size       = var.nfs_disk_size == 0 ? 200 : var.nfs_disk_size
   key_pair        = exoscale_ssh_keypair.ssh_key.name
   state           = "Running"
   zone            = var.zone

--- a/terraform/exoscale/modules/kubernetes-cluster/variables.tf
+++ b/terraform/exoscale/modules/kubernetes-cluster/variables.tf
@@ -17,11 +17,14 @@ variable "machines" {
     })
     provider_settings = object({
       es_local_storage_capacity = number
+      disk_size                 = number
     })
   }))
 }
 
 variable "nfs_size" {}
+
+variable "nfs_disk_size" {}
 
 variable "ssh_pub_key" {}
 

--- a/terraform/exoscale/variables.tf
+++ b/terraform/exoscale/variables.tf
@@ -29,6 +29,7 @@ variable machines_sc {
     })
     provider_settings = object({
       es_local_storage_capacity = number
+      disk_size                 = number
     })
   }))
 }
@@ -43,6 +44,7 @@ variable machines_wc {
     })
     provider_settings = object({
       es_local_storage_capacity = number
+      disk_size                 = number
     })
   }))
 }
@@ -51,6 +53,12 @@ variable nfs_size {
   description = "The size of the nfs machine"
   type        = string
   default     = "Small"
+}
+
+variable nfs_disk_size {
+  description = "The size of the nfs machines disk"
+  type        = number
+  default     = 200
 }
 
 variable ssh_pub_key_sc {


### PR DESCRIPTION
**What this PR does / why we need it**: Disc size need to be configurable on exoscale nodes. Main reason is because the volume size of elasticsearch is configurable and can otherwise be larger then the actual disc. 

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #12 

**Special notes for reviewer**:
Will change tfvars.json with an added field of `disc_size` per node and `nfs_disc_size`
**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [x] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
