### PR TITLE
Cleanup Dockerfile and e2e pipeline simulation script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,52 +9,30 @@ RUN make build
 FROM ubuntu:18.04
 
 ARG ANSIBLE_VERSION="2.5.1+dfsg-1ubuntu0.1"
-ARG KUBECTL_VERSION="v1.15.2"
+ARG KUBECTL_VERSION="1.15.2"
 ARG S3CMD_VERSION="2.0.2"
-ARG TERRAFORM_VERSION="0.12.19"
 ARG SOPS_VERSION="3.6.1"
+ARG TERRAFORM_VERSION="0.12.19"
+ARG YQ_VERSION="3.2.1"
 
 RUN  apt-get update && \
      apt-get install -y \
-         python3-pip make git wget \
-         unzip ssh gettext-base \
-         jq curl python3.7 apache2-utils \
-         ansible="${ANSIBLE_VERSION}" \
-         net-tools iputils-ping && \
+         python3-pip wget \
+         unzip ssh  \
+         jq curl python3.7 \
+         ansible="${ANSIBLE_VERSION}" && \
      rm -rf /var/lib/apt/lists/*
 
 # Terraform
-RUN wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-RUN unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+RUN wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     mv terraform /usr/local/bin/terraform && \
     rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 
 # Kubectl
-RUN wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+RUN wget "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
-
-# Helm
-ENV HELM_VERSION "v3.2.4"
-RUN wget "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
-    tar -zxvf "helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
-    mv linux-amd64/helm /usr/local/bin/helm && \
-    rm -rf linux-amd64/ "helm-${HELM_VERSION}-linux-amd64.tar.gz"
-# We need to use this variable to override the default data path for helm
-# TODO Change when this is closed https://github.com/helm/helm/issues/7919
-# Should come with v3.3.0, see https://github.com/helm/helm/pull/7983
-ENV XDG_DATA_HOME=/root/.config
-RUN helm plugin install https://github.com/databus23/helm-diff --version v3.1.1
-
-# Helmfile
-ENV HELMFILE_VERSION "v0.119.1"
-RUN wget "https://github.com/roboll/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_linux_amd64" && \
-    chmod +x helmfile_linux_amd64 && \
-    mv helmfile_linux_amd64 /usr/local/bin/helmfile
-
-# Pipenv
-RUN python3 -m pip install pip
-RUN python3.6 -m pip install pipenv
 
 # s3cmd
 RUN wget "https://github.com/s3tools/s3cmd/releases/download/v${S3CMD_VERSION}/s3cmd-${S3CMD_VERSION}.tar.gz" && \
@@ -66,7 +44,6 @@ RUN wget "https://github.com/s3tools/s3cmd/releases/download/v${S3CMD_VERSION}/s
     rm "s3cmd-${S3CMD_VERSION}.tar.gz"
 
 # yq
-ENV YQ_VERSION "3.2.1"
 RUN wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
     chmod +x yq_linux_amd64 && \
     mv yq_linux_amd64 /usr/local/bin/yq


### PR DESCRIPTION
**What this PR does / why we need it**:

This Dockerfile cleanup is the first step to be able to use the Docker images built for this project as the base for other ck8s projects using ckctl to setup clusters.

I tested the Dockerfile changes using the `pipeline/simulate.bash` script which runs the full e2e flow on Exoscale. Let's hope the actual pipelines continue running smoothly as well. :smile: 

**Special notes for reviewer**:

Not sure what commit message prefix to put on Dockerfile changes, feel free to come up with one otherwise let's just leave it empty for now. :)

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
