### PR TITLE
config: Update es disk size in dev flavor

### DIFF
--- a/api/exoscale/flavors.go
+++ b/api/exoscale/flavors.go
@@ -64,7 +64,7 @@ func Development(clusterType api.ClusterType, clusterName string) api.Cluster {
 	).WithProviderSettings(map[string]interface{}{
 		// Match ES_DATA_STORAGE_SIZE in config.sh
 		// Note that this value is in GB while config.sh uses Gi
-		"es_local_storage_capacity": 12,
+		"es_local_storage_capacity": 20,
 		"disk_size":                 50,
 	}).MustBuild()
 
@@ -75,7 +75,7 @@ func Development(clusterType api.ClusterType, clusterName string) api.Cluster {
 	).WithProviderSettings(map[string]interface{}{
 		// Match ES_DATA_STORAGE_SIZE in config.sh
 		// Note that this value is in GB while config.sh uses Gi
-		"es_local_storage_capacity": 12,
+		"es_local_storage_capacity": 20,
 		"disk_size":                 50,
 	}).MustBuild()
 

--- a/api/exoscale/flavors_test.go
+++ b/api/exoscale/flavors_test.go
@@ -92,7 +92,7 @@ func TestFlavors(t *testing.T) {
 						Size:     "Extra-large",
 						Image:    latestImage,
 						ProviderSettings: &MachineSettings{
-							ESLocalStorageCapacity: 12,
+							ESLocalStorageCapacity: 20,
 							DiskSize:               50,
 						},
 					},
@@ -101,7 +101,7 @@ func TestFlavors(t *testing.T) {
 						Size:     "Large",
 						Image:    latestImage,
 						ProviderSettings: &MachineSettings{
-							ESLocalStorageCapacity: 12,
+							ESLocalStorageCapacity: 20,
 							DiskSize:               50,
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
es_local_storage_capacity did not match the current apps configuration for the dev flavor.

**Which issue this PR fixes**:
N/A

**Public facing documentation PR** *(if applicable)*
N/A

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
