### PR TITLE
Make Docker more user-friendly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,14 @@ RUN wget "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-l
     chmod +x jq-linux64 && \
     mv jq-linux64 /usr/local/bin/jq
 
+COPY ./ansible /ck8s/ansible
+# TODO: Remove with https://github.com/elastisys/ck8s-cluster/issues/25
+COPY ./scripts/manage-s3-buckets.sh /ck8s/scripts/manage-s3-buckets.sh
+COPY ./terraform /ck8s/terraform
+
+ENV CK8S_CODE_PATH /ck8s
+ENV CK8S_CONFIG_PATH /ck8s-config
+
 COPY --from=0 /ck8s/dist/ck8s_linux_amd64 /usr/local/bin/ckctl
+
+ENTRYPOINT ["/usr/local/bin/ckctl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM golang:1.14.2-alpine3.11 as builder
 RUN apk add --no-cache make git
 
 WORKDIR /ck8s
-COPY . /ck8s
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
 RUN make build
 
 FROM ubuntu:18.04


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the first step to convert the Docker image from solely being a pipeline test tool to actually being useful for regular users. Especially useful when having to deal with different versions with different requirements and not having to clutter the local system.

I've opted not to expose this in the documentation or README for now. It still needs some internal testing before I would consider it ready for public consumption. But hopefully with some dog fooding and some other improvements (perhaps support for non-local SOPS providers)  it can become the go-to entrypoint.

The way I've been running it now is this:
```
docker build . -t ckctl:test
docker run --rm -it \
    -v "${CK8S_CONFIG_PATH}":/ck8s-config \
    -v "${HOME}/.gnupg":/root/.gnupg \
    -v "${HOME}/.terraformrc":/root/.terraformrc:ro \
    -e GPG_TTY=/dev/pts/0 \
    ckctl:test list --cluster sc
```

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

This will break the e2e pipeline until it has been updated as well.

@JonasKop would be really interesting to see if this works on mac. Maybe it would eliminate some of the cross-platform pains. :smile: 

For the rest of you, please let me know if this works with your setup as well!

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
