### PR TITLE
api: Make config and code paths absolute

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixed
+- Support relative config path.
+
 ### Changed
 - Upgrade jq to v1.6
 - Upgrade ansible to 2.9.14

--- a/api/path.go
+++ b/api/path.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 )
 
 type Path struct {
@@ -128,34 +129,52 @@ var relativeCodePaths = CodePath{
 	},
 }
 
-func NewConfigPath(configRootPath string, clusterType ClusterType) ConfigPath {
+func NewConfigPath(
+	configRootPath string,
+	clusterType ClusterType,
+) (ConfigPath, error) {
 	configPath := make(
 		ConfigPath,
 		len(relativeConfigPaths)+
 			len(clusterSpecificRelativeConfigPaths[clusterType]),
 	)
 	for id, p := range relativeConfigPaths {
+		fullPath, err := filepath.Abs(path.Join(configRootPath, p.Path))
+		if err != nil {
+			return nil, err
+		}
 		configPath[id] = Path{
-			Path:   path.Join(configRootPath, p.Path),
+			Path:   fullPath,
 			Format: p.Format,
 		}
 	}
 	for id, p := range clusterSpecificRelativeConfigPaths[clusterType] {
+		fullPath, err := filepath.Abs(path.Join(configRootPath, p.Path))
+		if err != nil {
+			return nil, err
+		}
 		configPath[id] = Path{
-			Path:   path.Join(configRootPath, p.Path),
+			Path:   fullPath,
 			Format: p.Format,
 		}
 	}
-	return configPath
+	return configPath, nil
 }
 
-func NewCodePath(codeRootPath string, clusterType ClusterType) CodePath {
+func NewCodePath(
+	codeRootPath string,
+	clusterType ClusterType,
+) (CodePath, error) {
 	codePath := make(CodePath, len(relativeCodePaths))
 	for id, p := range relativeCodePaths {
+		fullPath, err := filepath.Abs(path.Join(codeRootPath, p.Path))
+		if err != nil {
+			return nil, err
+		}
 		codePath[id] = Path{
-			Path:   path.Join(codeRootPath, p.Path),
+			Path:   fullPath,
 			Format: p.Format,
 		}
 	}
-	return codePath
+	return codePath, nil
 }

--- a/client/cluster_test.go
+++ b/client/cluster_test.go
@@ -44,11 +44,21 @@ func setupClusterClient(
 
 	testRunner := runner.NewTestRunner(t)
 
+	configPath, err := api.NewConfigPath(dir, api.ServiceCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	codePath, err := api.NewCodePath(dir, api.ServiceCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	configHandler := NewConfigHandler(
 		logger,
 		api.ServiceCluster,
-		api.NewConfigPath(dir, api.ServiceCluster),
-		api.NewCodePath(dir, api.ServiceCluster),
+		configPath,
+		codePath,
 	)
 
 	c, err := NewClusterClient(

--- a/cmd/ck8s/main.go
+++ b/cmd/ck8s/main.go
@@ -174,9 +174,15 @@ func newConfigHandler(
 		return nil, err
 	}
 
-	configPath := api.NewConfigPath(configRootPath, clusterType)
+	configPath, err := api.NewConfigPath(configRootPath, clusterType)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing config path: %s", err)
+	}
 
-	codePath := api.NewCodePath(codeRootPath, clusterType)
+	codePath, err := api.NewCodePath(codeRootPath, clusterType)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing code path: %s", err)
+	}
 
 	return client.NewConfigHandler(
 		logger,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes https://github.com/elastisys/ck8s-cluster/issues/63

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
