### PR TITLE
Make marketing happy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::$(git describe --tags --abbrev=0 HEAD)
+      - name: Get the ChangeLog
+        id: get_changelog
+        shell: bash
+        run: |
+          changelog=$(grep -B100 -m2 -- '----' CHANGELOG.md)
+          changelog="${changelog//'%'/'%25'}"
+          changelog="${changelog//$'\n'/'%0A'}"
+          changelog="${changelog//$'\r'/'%0D'}"
+
+          echo "$changelog"
+
+          echo "::set-output name=changelog::$changelog"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -27,4 +39,6 @@ jobs:
           tag_name: ${{ steps.get_version.outputs.VERSION }}
           release_name: ${{ steps.get_version.outputs.VERSION }}
           body: |
+            ${{ steps.get_changelog.outputs.changelog }}
+
             See [CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/${{ steps.get_version.outputs.VERSION }}/CHANGELOG.md) for details.


### PR DESCRIPTION
**What this PR does / why we need it**:

Make marketing happy by putting the body of the last changelog in the
emails they receive with each release. This ensures one click less for
staying up-to-date with the latest product developments.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #

Just a kind marketing request. :smile: 

**Public facing documentation PR** *(if applicable)*

NO

**Special notes for reviewer**:

I have copy-pasted the commands in my shell, and they work. However, I didn't want to test in GitHub Actions itself, for fear of disrupting release workflow.

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [X] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
