### PR TITLE
Some bugfixes

### DIFF
--- a/api/aws/tfvars.go
+++ b/api/aws/tfvars.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 
 	"github.com/elastisys/ck8s/api"
@@ -26,7 +28,10 @@ func (e *Cluster) AddMachine(
 	machine *api.Machine,
 ) (string, error) {
 	if name == "" {
-		name = uuid.New().String()
+		// TODO Find the root cause for this issue
+		name = strings.Replace(uuid.New().String(), "-", "", -1)
+		// TODO Create a more dynamic workaround for the too long names
+		name = name[:10]
 	}
 
 	machines := e.Machines()

--- a/api/exoscale/tfvars.go
+++ b/api/exoscale/tfvars.go
@@ -1,6 +1,8 @@
 package exoscale
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 
 	"github.com/elastisys/ck8s/api"
@@ -48,7 +50,10 @@ func (e *Cluster) AddMachine(
 	machine *api.Machine,
 ) (string, error) {
 	if name == "" {
-		name = uuid.New().String()
+		// TODO Find the root cause for this issue
+		name = strings.Replace(uuid.New().String(), "-", "", -1)
+		// TODO Create a more dynamic workaround for the too long names
+		name = name[:10]
 	}
 
 	machines := e.Machines()

--- a/api/machine.go
+++ b/api/machine.go
@@ -178,6 +178,9 @@ func decodeMachine(
 	}
 
 	providerSettings := cloudProvider.MachineSettings()
+	if providerSettings == nil {
+		return nil
+	}
 
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Metadata: nil,

--- a/api/openstack/tfvars.go
+++ b/api/openstack/tfvars.go
@@ -39,6 +39,8 @@ func (e *Cluster) AddMachine(
 	if name == "" {
 		// TODO Find the root cause for this issue
 		name = strings.Replace(uuid.New().String(), "-", "", -1)
+		// TODO Create a more dynamic workaround for the too long names
+		name = name[:10]
 	}
 
 	machines := e.Machines()

--- a/api/path.go
+++ b/api/path.go
@@ -54,7 +54,7 @@ const (
 	AnsiblePlaybookDeployKubernetesFile
 	AnsiblePlaybookPrepareNodesFile
 	AnsiblePlaybookJoinClusterFile
-	AnsiblePlaybookInfrustructureFiles
+	AnsiblePlaybookInfrastructureFiles
 	ManageS3BucketsScriptFile
 	TerraformTFEDir
 	// TODO: Would be nice to get rid of this and only have one single main
@@ -104,7 +104,7 @@ var relativeCodePaths = CodePath{
 	AnsiblePlaybookPrepareNodesFile: {
 		"ansible/prepare-nodes.yml", "yaml",
 	},
-	AnsiblePlaybookInfrustructureFiles: {
+	AnsiblePlaybookInfrastructureFiles: {
 		"ansible/infrastructure.yml", "yaml",
 	},
 	AnsiblePlaybookJoinClusterFile: {

--- a/client/cluster.go
+++ b/client/cluster.go
@@ -178,10 +178,9 @@ func (c *ClusterClient) Apply() error {
 		"ECK_BASE_DOMAIN": currentState.BaseDomain(),
 	})
 
-	if c.cluster.CloudProvider() == api.Safespring ||
-		c.cluster.CloudProvider() == api.CityCloud {
-		if err := c.ansible.Infrustructure(); err != nil {
-			return fmt.Errorf("error infrastructure: %w", err)
+	if c.cluster.CloudProvider() == api.Safespring {
+		if err := c.ansible.Infrastructure(); err != nil {
+			return fmt.Errorf("error updating loadbalancer: %w", err)
 		}
 	}
 
@@ -217,6 +216,12 @@ func (c *ClusterClient) Join(name string) (api.MachineState, error) {
 
 	if err := c.ansible.JoinCluster(); err != nil {
 		return machineState, fmt.Errorf("error joining cluster: %w", err)
+	}
+
+	if c.cluster.CloudProvider() == api.Safespring {
+		if err := c.ansible.Infrastructure(); err != nil {
+			return machineState, fmt.Errorf("error updating loadbalancer: %w", err)
+		}
 	}
 
 	return machineState, nil
@@ -487,6 +492,12 @@ func (c *ClusterClient) RemoveNode(name string) error {
 	}
 	if err := c.TerraformApply(); err != nil {
 		return fmt.Errorf("error applying Terraform config: %w", err)
+	}
+
+	if c.cluster.CloudProvider() == api.Safespring {
+		if err := c.ansible.Infrastructure(); err != nil {
+			return fmt.Errorf("error updating loadbalancer: %w", err)
+		}
 	}
 
 	return nil

--- a/client/config.go
+++ b/client/config.go
@@ -241,7 +241,7 @@ func (c *ConfigHandler) AnsibleRunnerConfig(
 		InventoryPath:     c.configPath[api.AnsibleInventoryFile].Path,
 
 		PlaybookPathDeployKubernetes: c.codePath[api.AnsiblePlaybookDeployKubernetesFile].Path,
-		PlaybookPathInfrastructure:   c.codePath[api.AnsiblePlaybookInfrustructureFiles].Path,
+		PlaybookPathInfrastructure:   c.codePath[api.AnsiblePlaybookInfrastructureFiles].Path,
 		PlaybookPathPrepareNodes:     c.codePath[api.AnsiblePlaybookPrepareNodesFile].Path,
 		PlaybookPathJoinCluster:      c.codePath[api.AnsiblePlaybookJoinClusterFile].Path,
 

--- a/runner/ansible.go
+++ b/runner/ansible.go
@@ -64,7 +64,7 @@ func (a *Ansible) AddEnv(env map[string]string) {
 	}
 }
 
-func (a *Ansible) Infrustructure() error {
+func (a *Ansible) Infrastructure() error {
 	return a.runner.Run(a.playbook(a.config.PlaybookPathInfrastructure))
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes to some bugs:

Temporary fix to too long node names:
Truncate the uuid that is generated to 10 characters. This is not the best fix and I know that @Xartos is working on something more dynamic. So if you want we could add this, otherwise I'll drop this commit in favor of waiting for the better fix.

A recent change to provider settings caused `ck8s add` to not work on non-exoscale providers.

When adding or removing a node in safespring we must also update the loadbalancer there (run the infrastructure ansible playbook). I added it to the `cluster.Join()` and `cluster.RemoveNode()` functions. Is there any other places this should also be added? Also, does it matter exactly where in the fuctions the call should be? If so, let me know where.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
No issues created for this.

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
This has only been tested for safespring. Let me know if you think that it needs to be tested anywhere else.

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
