### PR TITLE
aws: Allow extra_tags

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Initial Azure support.
 - Added new variables for the Kubernetes api server OIDC config.
+- `extra_tags` support for AWS.
 
 ### Removed
 

--- a/api/aws/tfvars.go
+++ b/api/aws/tfvars.go
@@ -18,9 +18,10 @@ type AWSTFVars struct {
 	MachinesSC map[string]*api.Machine `json:"machines_sc" validate:"required,min=1"`
 	MachinesWC map[string]*api.Machine `json:"machines_wc" validate:"required,min=1"`
 
-	PublicIngressCIDRWhitelist []string `json:"public_ingress_cidr_whitelist" validate:"required"`
-	APIServerWhitelist         []string `json:"api_server_whitelist" validate:"required"`
-	NodeportWhitelist          []string `json:"nodeport_whitelist" validate:"required"`
+	PublicIngressCIDRWhitelist []string          `json:"public_ingress_cidr_whitelist" validate:"required"`
+	APIServerWhitelist         []string          `json:"api_server_whitelist" validate:"required"`
+	NodeportWhitelist          []string          `json:"nodeport_whitelist" validate:"required"`
+	ExtraTags                  map[string]string `json:"extra_tags"`
 }
 
 func (e *Cluster) AddMachine(

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -27,7 +27,8 @@ module "service_cluster" {
 
   ssh_pub_key = var.ssh_pub_key_sc
 
-  machines = var.machines_sc
+  machines   = var.machines_sc
+  extra_tags = var.extra_tags
 }
 
 module "workload_cluster" {
@@ -43,5 +44,6 @@ module "workload_cluster" {
 
   ssh_pub_key = var.ssh_pub_key_wc
 
-  machines = var.machines_wc
+  machines   = var.machines_wc
+  extra_tags = var.extra_tags
 }

--- a/terraform/aws/modules/kubernetes-cluster/main.tf
+++ b/terraform/aws/modules/kubernetes-cluster/main.tf
@@ -366,10 +366,10 @@ resource "aws_instance" "master" {
 
   depends_on = [aws_internet_gateway.gateway]
 
-  tags = {
+  tags = merge({
     Name                                  = "${var.prefix}-${each.key}"
     "kubernetes.io/cluster/${var.prefix}" = "owned"
-  }
+  }, var.extra_tags)
 }
 
 
@@ -404,10 +404,10 @@ resource "aws_instance" "worker" {
 
   depends_on = [aws_internet_gateway.gateway]
 
-  tags = {
+  tags = merge({
     Name                                  = "${var.prefix}-${each.key}"
     "kubernetes.io/cluster/${var.prefix}" = "owned"
-  }
+  }, var.extra_tags)
 }
 
 

--- a/terraform/aws/modules/kubernetes-cluster/variables.tf
+++ b/terraform/aws/modules/kubernetes-cluster/variables.tf
@@ -32,3 +32,10 @@ variable machines {
     })
   }))
 }
+
+variable extra_tags {
+  default = {
+  }
+  description = "Any extra tags that should be present on each EC2 instance"
+  type        = map(string)
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -59,3 +59,10 @@ variable machines_wc {
     })
   }))
 }
+
+variable extra_tags {
+  default = {
+  }
+  description = "Any extra tags that should be present on each EC2 instance"
+  type        = map(string)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The security policies of some customers require all AWS EC2 instances to
be tagged in a standardized manner (e.g., Owner, Scope, Project, Team,
etc.).

This commit adds support for extra_tags in `tfvars.json`.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #

NA

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

Should eventually make it into https://compliantkubernetes.io/operator-manual/configuring/, once a structure is available.

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [NA] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
