### PR TITLE
all: Do not use short arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,13 @@ repos:
   rev: 2.1.4
   hooks:
     - id: shellcheck
+- repo: local
+  hooks:
+    - id: avoid-short-arguments
+      name: avoid-short-arguments
+      description: >-
+        Prevent usage of short arguments, which significantly hamper
+        readability and compatibility.
+      language: pygrep
+      entry: '[ "][-]A'
+      files: '^.*$'

--- a/ansible/templates/kubeadm-config.yaml.j2
+++ b/ansible/templates/kubeadm-config.yaml.j2
@@ -106,11 +106,6 @@ networking:
   podSubnet: {{ k8s_pod_cidr }}
   dnsDomain: "cluster.local"
 scheduler: {}
-# @todo:
-# private_registries:
-#     - url: harbor.test-gadr.a1ck.io
-#       user: admin
-#       password: BKjLJOz4S64PPaNxamyf
 
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1

--- a/runner/kubectl.go
+++ b/runner/kubectl.go
@@ -102,20 +102,20 @@ func (k *Kubectl) DeleteNode(name string) error {
 	return k.runner.Run(k.command("delete", "node", k.fullNodeName(name)))
 }
 
-// DeleteAll runs `sops exec-file KUBECONFIG 'kubectl delete RESOURCE -A --all EXTRAARGS...'
+// DeleteAll runs `sops exec-file KUBECONFIG 'kubectl delete RESOURCE --all-namespaces --all EXTRAARGS...'
 func (k *Kubectl) DeleteAll(resource string, extraArgs ...string) error {
 	k.logger.Debug("kubectl_delete_all", zap.String("resource", resource))
-	args := append([]string{"delete", resource, "-A", "--all"}, extraArgs...)
+	args := append([]string{"delete", resource, "--all-namespaces", "--all"}, extraArgs...)
 	return k.runner.Run(k.command(args...))
 }
 
-// DeleteAllTimeout runs `sops exec-file KUBECONFIG 'kubectl delete RESOURCE -A --all --timeout=TIMEOUTs EXTRAARGS...'
+// DeleteAllTimeout runs `sops exec-file KUBECONFIG 'kubectl delete RESOURCE --all-namespaces --all --timeout=TIMEOUTs EXTRAARGS...'
 func (k *Kubectl) DeleteAllTimeout(resource string, timeout int, extraArgs ...string) error {
 	k.logger.Debug("kubectl_delete_all_timeout", zap.String("resource", resource))
 	args := append([]string{
 		"delete",
 		resource,
-		"-A",
+		"--all-namespaces",
 		"--all",
 		fmt.Sprintf("--timeout=%ds", timeout),
 	}, extraArgs...)

--- a/runner/kubectl_test.go
+++ b/runner/kubectl_test.go
@@ -128,7 +128,7 @@ func TestKubectlDeleteAll(t *testing.T) {
 	wantCmd := NewCommand(
 		"sops", "exec-file", testKubectlConfig.KubeconfigPath,
 		fmt.Sprintf(
-			"KUBECONFIG={} kubectl delete %s -A --all %s",
+			"KUBECONFIG={} kubectl delete %s --all-namespaces --all %s",
 			testDeleteResource,
 			testDeleteExtraArgs,
 		),
@@ -155,7 +155,7 @@ func TestKubectlDeleteAllTimeout(t *testing.T) {
 	wantCmd := NewCommand(
 		"sops", "exec-file", testKubectlConfig.KubeconfigPath,
 		fmt.Sprintf(
-			"KUBECONFIG={} kubectl delete %s -A --all --timeout=%ds %s",
+			"KUBECONFIG={} kubectl delete %s --all-namespaces --all --timeout=%ds %s",
 			testDeleteResource,
 			testDeleteTimeout,
 			testDeleteExtraArgs,
@@ -183,7 +183,7 @@ func TestKubectlDeleteAllTimeoutErrorTimeout(t *testing.T) {
 	wantCmd := NewCommand(
 		"sops", "exec-file", testKubectlConfig.KubeconfigPath,
 		fmt.Sprintf(
-			"KUBECONFIG={} kubectl delete %s -A --all --timeout=%ds %s",
+			"KUBECONFIG={} kubectl delete %s --all-namespaces --all --timeout=%ds %s",
 			testDeleteResource,
 			testDeleteTimeout,
 			testDeleteExtraArgs,
@@ -215,7 +215,7 @@ func TestKubectlDeleteAllTimeoutError(t *testing.T) {
 	wantCmd := NewCommand(
 		"sops", "exec-file", testKubectlConfig.KubeconfigPath,
 		fmt.Sprintf(
-			"KUBECONFIG={} kubectl delete %s -A --all --timeout=%ds %s",
+			"KUBECONFIG={} kubectl delete %s --all-namespaces --all --timeout=%ds %s",
 			testDeleteResource,
 			testDeleteTimeout,
 			testDeleteExtraArgs,

--- a/terraform/exoscale/modules/kubernetes-cluster/templates/worker-cloud-init.tmpl
+++ b/terraform/exoscale/modules/kubernetes-cluster/templates/worker-cloud-init.tmpl
@@ -13,7 +13,7 @@ runcmd:
   #       pool it no longer can send traffic back to itself via the EIP IP
   #       address.
   #       Remove this if it ever gets solved.
-  - sudo iptables -t nat -A PREROUTING -d ${eip_ip_address} -j DNAT --to 127.0.0.1
+  - sudo iptables --table nat --append PREROUTING --destination ${eip_ip_address} --jump DNAT --to 127.0.0.1
   - if [ ! -f /mnt/elasticsearch.fs ]; then sudo dd if=/dev/zero of=/mnt/elasticsearch.fs bs=1024 count=$((${es_local_storage_capacity}*1024*1024)) && sudo mkfs.ext4 /mnt/elasticsearch.fs; fi
-  - sudo mkdir -p /mnt/disks/elasticsearch-node-local-storage && sudo chown nobody:nogroup /mnt/disks/elasticsearch-node-local-storage
+  - sudo mkdir --parents /mnt/disks/elasticsearch-node-local-storage && sudo chown nobody:nogroup /mnt/disks/elasticsearch-node-local-storage
   - sudo mount /mnt/elasticsearch.fs /mnt/disks/elasticsearch-node-local-storage


### PR DESCRIPTION
**What this PR does / why we need it**:

Using short arguments is a bad practice, significantly hampering
readability and compatibility.

Ideally, we should aim to eliminate all short arguments.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #

NA

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

NA

**Special notes for reviewer**:

**Checklist:**

- [X] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [X] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
