### PR TITLE
Conditional check if cloud is aws for node name check

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -12,6 +12,7 @@
 - Initial Azure support.
 - Added new variables for the Kubernetes api server OIDC config.
 - `extra_tags` support for AWS.
+- Check if cloud provider is AWS so node name tests can be executed
 
 ### Removed
 

--- a/runner/kubectl.go
+++ b/runner/kubectl.go
@@ -63,10 +63,13 @@ func (k *Kubectl) Command(args []string) error {
 
 // NodeExists runs `sops exec-file KUBECONFIG 'kubectl get node NAME'` in the
 // background. If the node is not found a NodeNotFoundErr error is returned.
-func (k *Kubectl) NodeExists(name string) error {
+func (k *Kubectl) NodeExists(name string, addPrefix bool) error {
 	k.logger.Debug("kubectl_node_exists")
 
-	cmd := k.command("get", "node", k.fullNodeName(name))
+	if addPrefix {
+		name = k.fullNodeName(name)
+	}
+	cmd := k.command("get", "node", (name))
 
 	// TODO: This assumes a lot about the command output. We should replace
 	// 		 this with a proper Kubernetes client lib implementation ASAP.

--- a/runner/kubectl_test.go
+++ b/runner/kubectl_test.go
@@ -36,7 +36,30 @@ func TestKubectlNodeExists(t *testing.T) {
 
 	k := NewKubectl(logger, r, testKubectlConfig)
 
-	if err := k.NodeExists(testNodeName); err != nil {
+	if err := k.NodeExists(testNodeName, true); err != nil {
+		t.Error(err)
+	}
+
+	logTest.Diff(t)
+}
+
+func TestKubectlNodeExistsPrefixFalse(t *testing.T) {
+	logTest, logger := testutil.NewTestLogger([]string{
+		"kubectl_node_exists",
+	})
+
+	r := NewTestRunner(t)
+
+	wantCmd := NewCommand(
+		"sops", "exec-file", testKubectlConfig.KubeconfigPath,
+		fmt.Sprintf("KUBECONFIG={} kubectl get node %s", testNodeName),
+	)
+
+	r.Push(&TestCommand{Command: wantCmd})
+
+	k := NewKubectl(logger, r, testKubectlConfig)
+
+	if err := k.NodeExists(testNodeName, false); err != nil {
 		t.Error(err)
 	}
 
@@ -59,7 +82,7 @@ func TestKubectlNodeExistsNotFound(t *testing.T) {
 
 	k := NewKubectl(logger, r, testKubectlConfig)
 
-	if err := k.NodeExists(testNodeName); !errors.Is(err, NodeNotFoundErr) {
+	if err := k.NodeExists(testNodeName, true); !errors.Is(err, NodeNotFoundErr) {
 		t.Error("expected NodeNotFoundErr")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:Checks if cloud is AWS.  Node name is then gotten a different way so that it can be tested

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:21
fixes #

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [ ] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [ ] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
