### PR TITLE
aws: Fix extra_tags

### DIFF
--- a/api/aws/flavors.go
+++ b/api/aws/flavors.go
@@ -33,6 +33,7 @@ func Default(clusterType api.ClusterType, clusterName string) *Cluster {
 			PublicIngressCIDRWhitelist: []string{},
 			APIServerWhitelist:         []string{},
 			NodeportWhitelist:          []string{},
+			ExtraTags:                  map[string]string{},
 		},
 	}
 }

--- a/api/aws/flavors_test.go
+++ b/api/aws/flavors_test.go
@@ -53,6 +53,7 @@ func TestFlavors(t *testing.T) {
 				PublicIngressCIDRWhitelist: []string{},
 				APIServerWhitelist:         []string{},
 				NodeportWhitelist:          []string{},
+				ExtraTags:                  map[string]string{},
 			},
 		},
 		got: Default(clusterType, clusterName),
@@ -90,6 +91,7 @@ func TestFlavors(t *testing.T) {
 				PublicIngressCIDRWhitelist: []string{},
 				APIServerWhitelist:         []string{},
 				NodeportWhitelist:          []string{},
+				ExtraTags:                  map[string]string{},
 
 				MachinesSC: map[string]*api.Machine{
 					"master-0": {
@@ -163,6 +165,7 @@ func TestFlavors(t *testing.T) {
 				PublicIngressCIDRWhitelist: []string{},
 				APIServerWhitelist:         []string{},
 				NodeportWhitelist:          []string{},
+				ExtraTags:                  map[string]string{},
 
 				MachinesSC: map[string]*api.Machine{
 					"master-0": {

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -256,6 +256,7 @@ func TestTFVarsRead(t *testing.T) {
 			PublicIngressCIDRWhitelist: []string{"1.2.3.4/32", "4.3.2.1/32"},
 			APIServerWhitelist:         []string{"1.2.3.4/32", "4.3.2.1/32"},
 			NodeportWhitelist:          []string{"1.2.3.4/32", "4.3.2.1/32"},
+			ExtraTags:                  map[string]string{},
 		},
 		got: aws.Default(clusterType, ""),
 	}} {

--- a/client/testdata/aws-tfvars.json
+++ b/client/testdata/aws-tfvars.json
@@ -50,5 +50,6 @@
   },
   "public_ingress_cidr_whitelist": ["1.2.3.4/32", "4.3.2.1/32"],
   "api_server_whitelist": ["1.2.3.4/32", "4.3.2.1/32"],
-  "nodeport_whitelist": ["1.2.3.4/32", "4.3.2.1/32"]
+  "nodeport_whitelist": ["1.2.3.4/32", "4.3.2.1/32"],
+  "extra_tags": {}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

ck8s_linux_amd64 (also called ckctl in the pipeline) initializes the
config file with *all* values, even default ones that the operator does
not or should not care about. Hence, when adding a new variable, it is
insufficient to add the default in the Terraform script, but this needs
to be also default-initialized in ckctl.

This script fixes a previously broken `extra_tags` contribution, that
omitted the default-initialization in the Go part.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:

fixes #103 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

NA

**Special notes for reviewer**:

**Checklist:**

- [NA] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [X] Proper commit message prefix on all commits
- [NA] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [X] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
