### PR TITLE
Retry terraform init for remote workspace on failure

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -702,7 +702,10 @@ func (c *ClusterClient) terraformRemoteWorkspaceApply() error {
 	}
 
 	if err := c.tfe.Init(); err != nil {
-		return fmt.Errorf("error initializing TFE workspace: %w", err)
+		c.logger.Warn("Initialization of terraform remote workspace failed, retrying...")
+		if err := c.tfe.Init(); err != nil {
+			return fmt.Errorf("error initializing TFE workspace: %w", err)
+		}
 	}
 
 	backendConfig, err := c.configHandler.readTerraformBackendConfig()


### PR DESCRIPTION
**What this PR does / why we need it**: This adds a single retry in case of failure when initializing the terraform remote workspace.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #18

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
This is very hard to test properly as the issue is flaky. I have attempted to run it a few time without seeing it and I have forced the retry by changing the code.
Please also note that I only added this retry to the terraform remote workspace init, not the init for the rest as I think we have only seen the issue with the remote workspace. Do you think we should add it to the other terraform init call as well?

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
