### PR TITLE
ansible: retry python installation

### DIFF
--- a/ansible/roles/internal_lb/tasks/main.yml
+++ b/ansible/roles/internal_lb/tasks/main.yml
@@ -1,12 +1,27 @@
 - name: Install pip
-  apt:
-    name:
-      - python3-setuptools
-      - virtualenv
-      - python3-pip
-    update_cache: yes
-  async: 600
-  poll: 30
+  block:
+    - name: Install python tools
+      apt:
+        name:
+          - python3-setuptools
+          - virtualenv
+          - python3-pip
+        update_cache: yes
+      async: 120
+      poll: 5
+  rescue:
+    # The above failed, so we need to cleanup and try again
+    - name: Fix interrupted dpkg
+      command: dpkg --configure -a
+    - name: Install python tools
+      apt:
+        name:
+          - python3-setuptools
+          - virtualenv
+          - python3-pip
+        update_cache: yes
+      async: 120
+      poll: 5
 
 - name: Install Docker Module for Python
   pip:


### PR DESCRIPTION
**What this PR does / why we need it**: This is an attempt to address #36 again by retrying the installation of pip instead of just waiting.

**Which issue this PR fixes**:
fixes #36

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
Here is an example run where the installation hung and then recovered successfully:
```
PLAY [internal_lb] **********************************************************************************************************************

TASK [internal_lb : Install python tools] ***********************************************************************************************
changed: [lennart-gcs-service-cluster-master-0]                                                                                          
changed: [lennart-gcs-service-cluster-worker-1]                                                                                          
fatal: [lennart-gcs-service-cluster-worker-0]: FAILED! => changed=false                                                                  
  msg: async task did not complete within the requested time - 120s

TASK [internal_lb : Fix interrupted dpkg] ***********************************************************************************************
changed: [lennart-gcs-service-cluster-worker-0]

TASK [internal_lb : Install python tools] ***********************************************************************************************
ok: [lennart-gcs-service-cluster-worker-0]                          

TASK [internal_lb : Install Docker Module for Python] ***********************************************************************************
changed: [lennart-gcs-service-cluster-worker-0]                     
changed: [lennart-gcs-service-cluster-master-0]                                                                                          
changed: [lennart-gcs-service-cluster-worker-1]
```


**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
