### PR TITLE
pipeline: Relax version requirement for ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make build
 
 FROM ubuntu:18.04
 
-ARG ANSIBLE_VERSION="2.9.14-1ppa~bionic"
+ARG ANSIBLE_VERSION="2.9.*"
 ARG JQ_VERSION="1.6"
 ARG KUBECTL_VERSION="1.15.2"
 ARG S3CMD_VERSION="2.0.2"
@@ -20,7 +20,7 @@ ARG TERRAFORM_VERSION="0.12.29"
 ARG YQ_VERSION="3.2.1"
 
 RUN apt-get update && \
-    apt install -y software-properties-common && \
+    apt-get install -y software-properties-common && \
     add-apt-repository --yes --update ppa:ansible/ansible-2.9 && \
     apt-get install -y \
         python3-pip wget \


### PR DESCRIPTION
**What this PR does / why we need it**:
The exact version we were using was dropped from the PPA. So I changed it to accept any patch version (2.9.*).
Also unify the dockerfile to use apt-get instead of apt (since apt doesn't have a stable interface yet).

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*:
fixes #106 

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
