### PR TITLE
tf safe: Allow missing output data

### DIFF
--- a/terraform/modules/openstack/vm/output.tf
+++ b/terraform/modules/openstack/vm/output.tf
@@ -19,8 +19,8 @@ output "instance_ips" {
   value = {
     for key, instance in openstack_compute_instance_v2.instance :
     instance.name => {
-      "private_ip" = openstack_networking_port_v2.port[key].all_fixed_ips.0,
-      "public_ip"  = openstack_compute_floatingip_v2.fip[key].address
+      "private_ip" = contains(keys(openstack_networking_port_v2.port), key) ? openstack_networking_port_v2.port[key].all_fixed_ips.0 : "",
+      "public_ip"  = contains(keys(openstack_compute_floatingip_v2.fip), key) ? openstack_compute_floatingip_v2.fip[key].address : ""
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
I had trouble cleaning up after the pipeline today because the FIP was gone, but not the servers. This caused errors when terraform tried to destroy the resources as there was an `invalid index` in the output.
To fix this I added these conditionals which allowed me to destroy the remaining resources.

**Which issue this PR fixes**: -

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:

**Checklist:**

- [ ] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
