### PR TITLE
bin: Add new ck8s image with k8s v1.18.12

### DIFF
--- a/WIP-CHANGELOG.md
+++ b/WIP-CHANGELOG.md
@@ -1,4 +1,9 @@
+### Release notes
+
+- The new default image is  now `ck8s-v1.18.12+ck8s1`.
+
 ### Added
 
 - `extra_tags` support for AWS.
 - Check if cloud provider is AWS so node name tests can be executed
+- New version of Kubernetes supported: v1.18.12

--- a/api/azure/cloudprovider.go
+++ b/api/azure/cloudprovider.go
@@ -5,6 +5,7 @@ import "github.com/elastisys/ck8s/api"
 var supportedImages = []*api.Image{
 	api.NewImage("ck8s-v1.16.14-ck8s0", "v1.16.14"),
 	api.NewImage("ck8s-v1.17.11-ck8s0", "v1.17.11"),
+	api.NewImage("ck8s-v1.18.12+ck8s1", "v1.18.12"),
 }
 
 var clusterFlavorMap = map[api.ClusterFlavor]func(api.ClusterType, string) api.Cluster{

--- a/api/citycloud/cloudprovider.go
+++ b/api/citycloud/cloudprovider.go
@@ -9,6 +9,7 @@ var supportedImages = []*api.Image{
 	api.NewImage("ck8s-v1.15.12+ck8s0", "v1.15.12"),
 	api.NewImage("ck8s-v1.16.14+ck8s0", "v1.16.14"),
 	api.NewImage("ck8s-v1.17.11+ck8s0", "v1.17.11"),
+	api.NewImage("ck8s-v1.18.12+ck8s1", "v1.18.12"),
 }
 
 var clusterFlavorMap = map[api.ClusterFlavor]func(api.ClusterType, string) api.Cluster{

--- a/api/exoscale/cloudprovider.go
+++ b/api/exoscale/cloudprovider.go
@@ -7,6 +7,7 @@ var supportedImages = []*api.Image{
 	api.NewImage("ck8s-v1.15.12+ck8s0", "v1.15.12"),
 	api.NewImage("ck8s-v1.16.14+ck8s0", "v1.16.14"),
 	api.NewImage("ck8s-v1.17.11+ck8s0", "v1.17.11"),
+	api.NewImage("ck8s-v1.18.12+ck8s1", "v1.18.12"),
 }
 
 var clusterFlavorMap = map[api.ClusterFlavor]func(api.ClusterType, string) api.Cluster{

--- a/api/safespring/cloudprovider.go
+++ b/api/safespring/cloudprovider.go
@@ -10,6 +10,7 @@ var (
 		api.NewImage("ck8s-v1.15.12+ck8s0", "v1.15.12"),
 		api.NewImage("ck8s-v1.16.14+ck8s0", "v1.16.14"),
 		api.NewImage("ck8s-v1.17.11+ck8s0", "v1.17.11"),
+		api.NewImage("ck8s-v1.18.12+ck8s1", "v1.18.12"),
 	}
 
 	supportedImages = map[api.NodeType][]*api.Image{


### PR DESCRIPTION
**What this PR does / why we need it**: It simply bumps the default version by adding a new supported image.

**Which issue this PR fixes** *(use the format `fixes #<issue number>(, fixes #<issue_number>, ...)` to automatically close the issue when PR gets merged)*: -

**Public facing documentation PR** *(if applicable)*
<!-- https://github.com/elastisys/compliantkubernetes/pull/ -->

**Special notes for reviewer**:
I did not add this image for AWS since I noticed that it didn't have the previous image either. Maybe we can add it after some more testing to make sure that AWS works?

**Checklist:**

- [x] Added relevant notes to [WIP-CHANGELOG.md](https://github.com/elastisys/ck8s-cluster/blob/master/WIP-CHANGELOG.md)
- [x] Proper commit message prefix on all commits
- [ ] Updated the [public facing documentation](https://github.com/elastisys/compliantkubernetes)
- Is this changeset backwards compatible for existing clusters? Applying:
    - [x] is completely transparent, will not impact the workload in any way.
    - [ ] requires running a migration script.
    - [ ] will create noticeable cluster degradation.
          E.g. logs or metrics are not being collected or Kubernetes API server
          will not be responding while upgrading.
    - [ ] requires draining and/or replacing nodes.
    - [ ] will change any APIs.
          E.g. removes or changes any CK8S config options or Kubernetes APIs.
    - [ ] will break the cluster.
          I.e. full cluster migration is required.


<!--
Here are the commit prefixes and comments on when to use them:
all: things that touch on more than one of the areas below, or don't fit any of them
tf: Terraform code that apply to more than one cloud
tf aws: Terraform code that apply only to AWS
tf exo: Terraform code that apply only to Exoscale
tf safe: Terraform code that apply only to Safespring
tf city: Terraform code that apply only to CityCloud
ansible: Ansible related changes, e.g. cluster initialization or join
docs: documentation
pipeline: the pipeline
release: anything release related

Example commit prefix usage:

git commit -m "docs: Add instructions for how to do x"
-->
